### PR TITLE
Potential fix for code scanning alert no. 1: Disabling certificate validation

### DIFF
--- a/actions-runner/bin/checkScripts/downloadCert.js
+++ b/actions-runner/bin/checkScripts/downloadCert.js
@@ -10,7 +10,7 @@ const proxyPort = process.env['PROXYPORT'] || ''
 const proxyUsername = process.env['PROXYUSERNAME'] || ''
 const proxyPassword = process.env['PROXYPASSWORD'] || ''
 
-process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
+// Ensure certificate validation is enabled
 
 if (proxyHost === '') {
     const options = {


### PR DESCRIPTION
Potential fix for [https://github.com/zarkius/APP1/security/code-scanning/1](https://github.com/zarkius/APP1/security/code-scanning/1)

To fix the problem, we need to ensure that certificate validation is not disabled. This involves removing or modifying the line that sets `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to '0'. Instead, we should allow the default behavior of Node.js to validate certificates. If there is a need to handle self-signed certificates or other specific cases, we should handle them in a secure manner, such as by adding the necessary certificates to the trusted store.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
